### PR TITLE
Prioritize general_rating over rating field for card rating display

### DIFF
--- a/public/index-video.html
+++ b/public/index-video.html
@@ -815,11 +815,11 @@
       const coords = item.point ? [item.point.lon, item.point.lat] : city.center;
       
       let rating = '4.0';
-      // Check for different rating field structures in 2GIS API
-      if (item.reviews && typeof item.reviews.rating === 'number') {
-        rating = item.reviews.rating.toFixed(1);
-      } else if (item.reviews && item.reviews.general_rating && typeof item.reviews.general_rating === 'number') {
+      // Check for different rating field structures in 2GIS API - prioritizing general_rating
+      if (item.reviews && item.reviews.general_rating && typeof item.reviews.general_rating === 'number') {
         rating = item.reviews.general_rating.toFixed(1);
+      } else if (item.reviews && typeof item.reviews.rating === 'number') {
+        rating = item.reviews.rating.toFixed(1);
       } else if (item.reviews && item.reviews.average_rating && typeof item.reviews.average_rating === 'number') {
         rating = item.reviews.average_rating.toFixed(1);
       } else if (typeof item.rating === 'number') {


### PR DESCRIPTION
- Modified rating logic in index-video.html to check general_rating first
- Ensures general_rating is used when available instead of rating field
- Maintains existing fallback chain for compatibility